### PR TITLE
missing trailing slash to find nginx.conf on lapis server

### DIFF
--- a/lapis/cmd/actions.moon
+++ b/lapis/cmd/actions.moon
@@ -67,7 +67,7 @@ tasks = {
 
       os.execute "touch logs/error.log"
       os.execute "touch logs/access.log"
-      os.execute "LAPIS_ENVIRONMENT='#{environment}' " .. nginx .. ' -p "$(pwd)" -c "nginx.conf.compiled"'
+      os.execute "LAPIS_ENVIRONMENT='#{environment}' " .. nginx .. ' -p "$(pwd)"/ -c "nginx.conf.compiled"'
   }
 
   {


### PR DESCRIPTION
perhaps it's just me but this problem happens anytime I set up an environment for lapis environment (for MacOSX 10.6.8 and openresty 1.2.3.8)

whenever I'm ready to do a `lapis server` i get this error:

``` bash
/brainslug(master) $ lapis server
->  wrote   nginx.conf.compiled
->  made directory  logs
nginx: [emerg] open() "/Users/solso/brainslugnginx.conf.compiled" failed (2: No such file or directory)
```

the issue is that nginx expects the prefix path to have a trailing slash

``` bash
/opt/openresty/nginx/sbin/nginx -h
...
  -p prefix     : set prefix path (default: /opt/openresty/nginx/)
```

the way the lapis nginx cmd action is build up there is no slash between the path (from `pwd`) and the nginx.conf.compiled file, thus tries to get:

`/Users/solso/brainslugnginx.conf.compiled`

instead of

`/Users/solso/brainslug/nginx.conf.compiled`

the fix might end up adding and extra slash, harmless but ugly.

i really don't understand how come this problem has not appeared no others, afaik, pwd always returns the directory without a trailing slash. If only happens to me, then feed free to disregard. I'm following instructions to the letter and I always end up having to add the / after the pwd, no matter if I install lapis using --local or not (always from luarocks, not from source).
