### PR TITLE
fix lapis/cmd/nginx.lua to support newer openresty versions

### DIFF
--- a/lapis/cmd/nginx.lua
+++ b/lapis/cmd/nginx.lua
@@ -25,7 +25,7 @@ do
       local handle = io.popen(cmd)
       local out = handle:read()
       handle:close()
-      local matched = out:match("^nginx version: ngx_openresty/" or out:match("^nginx version: openresty/"))
+      local matched = out:match("^nginx version: ngx_openresty/") or out:match("^nginx version: openresty/")
       if matched then
         nginx_path = tostring(prefix) .. tostring(nginx_bin)
         return nginx_path

--- a/lapis/cmd/nginx.moon
+++ b/lapis/cmd/nginx.moon
@@ -24,7 +24,7 @@ find_nginx = do
       out = handle\read!
       handle\close!
 
-      matched = out\match "^nginx version: ngx_openresty/" or out\match "^nginx version: openresty/"
+      matched = out\match"^nginx version: ngx_openresty/" or out\match"^nginx version: openresty/"
 
       if matched
         nginx_path = "#{prefix}#{nginx_bin}"


### PR DESCRIPTION
A fix that I made to support the new openresty version
