### PR TITLE
Add index method and tablespace to create index 

### DIFF
--- a/lapis/db/schema.moon
+++ b/lapis/db/schema.moon
@@ -54,7 +54,7 @@ create_index = (tname, ...) ->
 
   buffer = {"CREATE"}
   append_all buffer, " UNIQUE" if options.unique
-  append_all buffer, " INDEX ON #{db.escape_identifier tname} "
+  append_all buffer, " INDEX ON #{db.escape_identifier tname}"
 
   if options.method
     append_all buffer, " USING ", options.method
@@ -68,7 +68,7 @@ create_index = (tname, ...) ->
   append_all buffer, ")"
 
   if options.tablespace
-    append_all buffer, " TABLESPACE", options.tablespace
+    append_all buffer, " TABLESPACE ", options.tablespace
     
   if options.where
     append_all buffer, " WHERE ", options.where


### PR DESCRIPTION
According to postgresql syntax index method (USING btree) and tablespace was added.
This things is very usefull.

http://www.postgresql.org/docs/9.3/static/sql-createindex.html
