### PR TITLE
add search path for openresty installed via brew on OSX

### DIFF
--- a/lapis/cmd/nginx.lua
+++ b/lapis/cmd/nginx.lua
@@ -11,6 +11,7 @@ do
   local nginx_bin = "nginx"
   local nginx_search_paths = {
     "/usr/local/openresty/nginx/sbin/",
+    "/usr/local/opt/openresty/bin/",
     "/usr/sbin/",
     ""
   }

--- a/lapis/cmd/nginx.moon
+++ b/lapis/cmd/nginx.moon
@@ -11,6 +11,7 @@ find_nginx = do
   nginx_bin = "nginx"
   nginx_search_paths = {
     "/usr/local/openresty/nginx/sbin/"
+    "/usr/local/opt/openresty/bin/"
     "/usr/sbin/"
     ""
   }


### PR DESCRIPTION
installing openresty via homebrew puts it in `/usr/local/opt/`
