### PR TITLE
Use correct variable

### DIFF
--- a/lapis/cmd/nginx.moon
+++ b/lapis/cmd/nginx.moon
@@ -38,7 +38,7 @@ filters = {
         db = assert val.database, "missing database name"
         val.user or "postgres", val.password or "", val.host or "127.0.0.1", db
       when "string"
-        url\match "^postgres://(.*):(.*)@(.*)/(.*)$"
+        val\match "^postgres://(.*):(.*)@(.*)/(.*)$"
 
     error "failed to create postgres connect string" unless user
     "%s dbname=%s user=%s password=%s"\format host, db, user, password


### PR DESCRIPTION
Fixes:

```
Error: /usr/local/share/lua/5.1/lapis/cmd/nginx.lua:45: attempt to index global 'url' (a nil value)
stack traceback:
    /usr/local/share/lua/5.1/lapis/cmd/nginx.lua:45: in function </usr/local/share/lua/5.1/lapis/cmd/nginx.lua:38>
    (tail call): ?
    [C]: in function 'gsub'
    /usr/local/share/lua/5.1/lapis/cmd/nginx.lua:83: in function 'compile_config'
    /usr/local/share/lua/5.1/lapis/cmd/nginx.lua:118: in function 'write_config_for'
    /usr/local/share/lua/5.1/lapis/cmd/actions.lua:143: in function </usr/local/share/lua/5.1/lapis/cmd/actions.lua:135>
    (tail call): ?
    [C]: in function 'xpcall'
    /usr/local/share/lua/5.1/lapis/cmd/actions.lua:332: in function 'execute'
    /usr/local/lib/luarocks/rocks/lapis/dev-1/bin/lapis:4: in main chunk
    [C]: ?
```
