### PR TITLE
fix `lapis.serve("my-app")` for Lua-style applications.

### DIFF
--- a/lapis/init.lua
+++ b/lapis/init.lua
@@ -11,15 +11,17 @@ local serve
 serve = function(app_cls)
   local app = app_cache[app_cls]
   if not (app) then
-    if type(app_cls) == "string" then
-      app = require(app_cls)()
-    elseif app_cls.__base then
+    local name = app_cls
+    if type(name) == "string" then
+      app_cls = require(name)
+    end
+    if app_cls.__base then
       app = app_cls()
     else
       app_cls:build_router()
       app = app_cls
     end
-    app_cache[app_cls] = app
+    app_cache[name] = app
   end
   return dispatch(app)
 end

--- a/lapis/init.moon
+++ b/lapis/init.moon
@@ -10,15 +10,17 @@ serve = (app_cls) ->
   app = app_cache[app_cls]
 
   unless app
-    app = if type(app_cls) == "string"
-      require(app_cls)!
-    elseif app_cls.__base -- is a class
+    name = app_cls
+    if type(name) == "string"
+      app_cls = require(name)
+
+    app = if app_cls.__base -- is a class
       app_cls!
     else
       app_cls\build_router!
       app_cls
 
-    app_cache[app_cls] = app
+    app_cache[name] = app
 
   dispatch app
 


### PR DESCRIPTION
The current code tries to call the `Application()` instance returned by the `my-app.lua` file:

```
runtime error: /usr/local/share/lua/5.1/lapis/init.lua:15: attempt to call a table value.
```
