### PR TITLE
Add `require.lua` dependency to load `.moon` files directly. Adapt the templates. `moonc` begone!

### DIFF
--- a/lapis-dev-1.rockspec
+++ b/lapis-dev-1.rockspec
@@ -22,6 +22,7 @@ dependencies = {
 	"lua-cjson",
 	"luasocket",
 	"pgmoon",
+	"require",
 }
 
 build = {

--- a/lapis/cmd/actions.lua
+++ b/lapis/cmd/actions.lua
@@ -110,12 +110,13 @@ tasks = {
       if path.exists("nginx.conf") then
         fail_with_message("nginx.conf already exists")
       end
-      write_file_safe("nginx.conf", require("lapis.cmd.templates.config"))
       write_file_safe("mime.types", require("lapis.cmd.templates.mime_types"))
       if flags.lua then
         write_file_safe("app.lua", require("lapis.cmd.templates.app_lua"))
+        write_file_safe("nginx.conf", require("lapis.cmd.templates.config_lua"))
       else
         write_file_safe("app.moon", require("lapis.cmd.templates.app"))
+        write_file_safe("nginx.conf", require("lapis.cmd.templates.config"))
       end
       if flags.git then
         write_file_safe(".gitignore", require("lapis.cmd.templates.gitignore")(flags))

--- a/lapis/cmd/actions.moon
+++ b/lapis/cmd/actions.moon
@@ -71,13 +71,14 @@ tasks = {
       if path.exists "nginx.conf"
         fail_with_message "nginx.conf already exists"
 
-      write_file_safe "nginx.conf", require "lapis.cmd.templates.config"
       write_file_safe "mime.types", require "lapis.cmd.templates.mime_types"
 
       if flags.lua
         write_file_safe "app.lua", require "lapis.cmd.templates.app_lua"
+        write_file_safe "nginx.conf", require "lapis.cmd.templates.config_lua"
       else
         write_file_safe "app.moon", require "lapis.cmd.templates.app"
+        write_file_safe "nginx.conf", require "lapis.cmd.templates.config"
 
       if flags.git
         write_file_safe ".gitignore", require("lapis.cmd.templates.gitignore") flags

--- a/lapis/cmd/templates/config.moon
+++ b/lapis/cmd/templates/config.moon
@@ -9,6 +9,12 @@ events {
 }
 
 http {
+  init_by_lua'
+    require = require"require".require
+    require"moonscript"
+    lapis = require"lapis"
+  ';
+
   include mime.types;
 
   server {
@@ -18,7 +24,7 @@ http {
     location / {
       default_type text/html;
       content_by_lua '
-        require("lapis").serve("app")
+        lapis.serve("app")
       ';
     }
 

--- a/lapis/cmd/templates/config_lua.lua
+++ b/lapis/cmd/templates/config_lua.lua
@@ -8,8 +8,6 @@ events {
 
 http {
   init_by_lua'
-    require = require"require".require
-    require"moonscript"
     lapis = require"lapis"
   ';
 

--- a/lapis/cmd/templates/config_lua.moon
+++ b/lapis/cmd/templates/config_lua.moon
@@ -1,4 +1,6 @@
-return [[worker_processes ${{NUM_WORKERS}};
+
+[[
+worker_processes ${{NUM_WORKERS}};
 error_log stderr notice;
 daemon off;
 
@@ -8,8 +10,6 @@ events {
 
 http {
   init_by_lua'
-    require = require"require".require
-    require"moonscript"
     lapis = require"lapis"
   ';
 


### PR DESCRIPTION
Assuming you're interested, `require.lua` may need some more testing before this is merged in.

It is AFAICT identical in behavior to the original, but I might have missed something.

----

Edit: Another advantage of require.lua is that it can be compiled by LuaJIT. If it improves the global performance of apps, we might as well add it to the Lua version of `config.nginx`.