### PR TITLE
Fix string value escaping.

### DIFF
--- a/lapis/nginx/postgres.lua
+++ b/lapis/nginx/postgres.lua
@@ -139,7 +139,7 @@ escape_literal = function(val)
   if "number" == _exp_0 then
     return tostring(val)
   elseif "string" == _exp_0 then
-    return "'" .. tostring((val:gsub("'", "''"))) .. "'"
+    return "'" .. tostring((val:gsub("[\\']", "\\%0"))) .. "'"
   elseif "boolean" == _exp_0 then
     return val and "TRUE" or "FALSE"
   elseif "table" == _exp_0 then

--- a/lapis/nginx/postgres.moon
+++ b/lapis/nginx/postgres.moon
@@ -111,7 +111,7 @@ escape_literal = (val) ->
     when "number"
       return tostring val
     when "string"
-      return "'#{(val\gsub "'", "''")}'"
+      return "'#{(val\gsub "[\\']", "\\%0")}'"
     when "boolean"
       return val and "TRUE" or "FALSE"
     when "table"


### PR DESCRIPTION
Postgres supports `\'` as an alternate escape sequence for quotes in strings.

A string like `[[\'...]]` would end up `[['\''...']]`, which would allow to build invalid queries.

Edit: not that this will also disable the other escape sequences  (`\ooo`, `\xhh`, `\uXXXX`, etc)
