### PR TITLE
Add config flag to disable reading request body

### DIFF
--- a/lapis/config.lua
+++ b/lapis/config.lua
@@ -1,5 +1,8 @@
 local insert
-insert = table.insert
+do
+  local _obj_0 = table
+  insert = _obj_0.insert
+end
 local config_cache, configs, default_config, merge_set, set, scope_meta, config, reset, run_with_scope, get_env, get
 config_cache = { }
 configs = { }
@@ -9,6 +12,7 @@ default_config = {
   session_name = "lapis_session",
   code_cache = "off",
   num_workers = "1",
+  allow_read_body = true,
   logging = {
     queries = true,
     requests = true

--- a/lapis/config.moon
+++ b/lapis/config.moon
@@ -12,6 +12,7 @@ default_config = {
   session_name: "lapis_session"
   code_cache: "off"
   num_workers: "1"
+  allow_read_body: true -- set to false if you don't want lapis to ready request body (ideal for proxying)
 
   logging: {
     queries: true


### PR DESCRIPTION
This change adds a config flag to disable reading the request body. It is turned `on` by default, so the default behavior doesn't change. Not reading the request body is useful when you have a lapis app that is proxying the inbound request to an alternate server.

See https://github.com/leafo/lapis/issues/161
