### PR TITLE
json_params: Fixed reading request's JSON body.

### DIFF
--- a/lapis/application.moon
+++ b/lapis/application.moon
@@ -499,6 +499,7 @@ json_params = (fn) ->
     if content_type = @req.headers["content-type"]
       -- Header often ends with ;UTF-8
       if string.find content_type\lower!, "application/json", nil, true
+        ngx.req.read_body!
         local obj
         pcall -> obj, err = json.decode ngx.req.get_body_data!
         @add_params obj, "json" if obj


### PR DESCRIPTION
Fixes empty `@params` when making a JSON request, currently `@json` is always nil.
