### PR TITLE
patch for has_many rows using include_in

### DIFF
--- a/lapis/db/model.lua
+++ b/lapis/db/model.lua
@@ -11,7 +11,10 @@ do
 end
 local cjson = require("cjson")
 local OffsetPaginator
-OffsetPaginator = require("lapis.db.pagination").OffsetPaginator
+do
+  local _obj_0 = require("lapis.db.pagination")
+  OffsetPaginator = _obj_0.OffsetPaginator
+end
 local singularize, Enum, enum, add_relations, Model
 singularize = function(name)
   return name:match("^(.*)s$") or name
@@ -396,6 +399,7 @@ do
   self.include_in = function(self, other_records, foreign_key, opts)
     local fields = opts and opts.fields or "*"
     local flip = opts and opts.flip
+    local has_many = opts and opts.has_many
     if not flip and type(self.primary_key) == "table" then
       error("model must have singular primary key to include")
     end
@@ -455,7 +459,16 @@ do
           local records = { }
           for _index_0 = 1, #res do
             local t = res[_index_0]
-            records[t[find_by]] = self:load(t)
+            local t_key = t[find_by]
+            local data = self:load(t)
+            if has_many then
+              if records[t_key] == nil then
+                records[t_key] = { }
+              end
+              table.insert(records[t_key], data)
+            else
+              records[t_key] = data
+            end
           end
           local field_name
           if opts and opts.as then

--- a/lapis/db/model.moon
+++ b/lapis/db/model.moon
@@ -192,6 +192,7 @@ class Model
   @include_in: (other_records, foreign_key, opts) =>
     fields = opts and opts.fields or "*"
     flip = opts and opts.flip
+    has_many = opts and opts.has_many
 
     if not flip and type(@primary_key) == "table"
       error "model must have singular primary key to include"
@@ -221,7 +222,16 @@ class Model
       if res = db.select query
         records = {}
         for t in *res
-          records[t[find_by]] = @load t
+          t_key = t[find_by]
+          data = @load t
+          
+          if has_many
+            if records[t_key] == nil
+              records[t_key] = {}
+
+            table.insert(records[t_key], data)
+          else
+            records[t_key] = data
 
         field_name = if opts and opts.as
           opts.as


### PR DESCRIPTION
When include_in is used in "one-to-many", the comment in code says: 

model.moon#L145
  -- -- .... (be careful of many to one, only one will be
  -- -- assigned but all will be fetched)

This patch accept the key has_many: true for retrieve all results.

