### PR TITLE
documentation fixes

### DIFF
--- a/docs/etlua_templates.md
+++ b/docs/etlua_templates.md
@@ -148,7 +148,7 @@ URL to a named route:
 <div class="about_page">
   <p>This is a great page!</p>
   <p>
-    <a href="<% url_for("index") %>">Return home</a>
+    <a href="<%= url_for("index") %>">Return home</a>
   </p>
 </div>
 ```
@@ -172,8 +172,8 @@ To render a sub-template you can use the `render` helper function:
 ```html
 <!-- views/navigation.etlua -->
 <div class="nav_bar">
-  <a href="<% url_for("index") %>">Home</a>
-  <a href="<% url_for("about") %>">About</a>
+  <a href="<%= url_for("index") %>">Home</a>
+  <a href="<%= url_for("about") %>">About</a>
 </div>
 ```
 

--- a/docs/html_generation.md
+++ b/docs/html_generation.md
@@ -179,7 +179,7 @@ print widget\render_to_string!
 ```
 
 If you want to use helpers like `@url_for` you also need to include them in the
-widget instance. Any object can be included as a helper, and it's methods will
+widget instance. Any object can be included as a helper, and its methods will
 be made available inside of the widget.
 
 ```moon

--- a/docs/moon_getting_started.md
+++ b/docs/moon_getting_started.md
@@ -66,7 +66,7 @@ class App extends lapis.Application
     -- Render HTML inline for simplicity
     @html ->
       h1 "My homepage"
-      a href: @url_for("foods"), "Check out my favorite foods"
+      a href: @url_for("list_foods"), "Check out my favorite foods"
 
   [list_foods: "/foods"]: =>
     @html ->


### PR DESCRIPTION
- In `docs/etlua_templates`, use `<%= url_for %>` instead of `<% url_for %>`.
- Fix a minor grammar issue in `docs/html_generation`.
- Address #292 in `docs/moon_getting_started`.