### PR TITLE
add uuid column type to mysql db

### DIFF
--- a/lapis/db/mysql/schema.moon
+++ b/lapis/db/mysql/schema.moon
@@ -183,6 +183,7 @@ types = setmetatable {
   timestamp:    C "TIMESTAMP"
   datetime:     C "DATETIME"
   boolean:      C "TINYINT", length: 1
+  uuid:         C "BINARY", length: 16
 }, __index: (key) =>
   error "Don't know column type `#{key}`"
 
@@ -201,4 +202,3 @@ types = setmetatable {
   :rename_column
   :rename_table
 }
-


### PR DESCRIPTION
Not sure if this is right or not, or if there's a better way.
I wanted to store uuid's in the db, and based on this stackoverflow post I've been using BINARY(16) to do it. Since there's no BINARY type i was going to just add that, but then it would be odd just to gve it a length of 16 just to store uuid's
http://stackoverflow.com/questions/10950202/how-to-store-uuid-as-number

Let me know if I've missed something, cheers!

