### PR TITLE
Fix a typo in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,7 +265,7 @@ config "development", ->
   measure_performance true
 
 class App extends lapis.Application
-  @before_filter: =>
+  @before_filter =>
     after_dispatch ->
       print to_json(ngx.ctx.performance)
 


### PR DESCRIPTION
Just a quick fix: the Configuration docs page was showing how to use `before_filter` to register an `after_dispatch` handler so perf data is output to the log. Though the correct syntax is `@before_filter => ...` (as `before_filter` is a function in `Application`), the page showed `@before_filter: =>` which did something else (overrode the local, inherited field of the class).

I've spent the last 30 minutes trying to figure out what was happening and went bug-hunting through the Lapis code---the colon was really easy to miss, and I'm a MoonScript/Lapis novice to boot. So I guess this, although minor, should be fixed to make life easier for somebody else :)