### PR TITLE
Improved HTTP verb handling

### DIFF
--- a/lapis/application.lua
+++ b/lapis/application.lua
@@ -657,6 +657,25 @@ do
     return out
   end
 end
+local restrict
+restrict = function(methods, action)
+  if action == nil then
+    action = methods
+    methods = {
+      'GET',
+      'HEAD'
+    }
+  end
+  return function(self)
+    for _index_0 = 1, #methods do
+      local method = methods[_index_0]
+      if self.req.cmd_mth == method then
+        return action(self)
+      end
+    end
+    return self.app.handle_405(self, methods)
+  end
+end
 local default_error_response
 default_error_response = function()
   return {
@@ -739,6 +758,7 @@ return {
   Request = Request,
   Application = Application,
   respond_to = respond_to,
+  restrict = restrict,
   capture_errors = capture_errors,
   capture_errors_json = capture_errors_json,
   json_params = json_params,

--- a/lapis/application.moon
+++ b/lapis/application.moon
@@ -412,6 +412,10 @@ class Application
 
   handle_404: =>
     error "Failed to find route: #{@req.cmd_url}"
+  
+  handle_405: (allowed) =>
+    @res.headers["Allow"] = table.concat allowed, ", "
+    status: 405, layout: false
 
   handle_error: (err, trace, error_page=@app.error_page) =>
     r = @app.Request @, @req, @res
@@ -453,8 +457,11 @@ respond_to = do
         if before = tbl.before
           return if run_before_filter before, @
         fn @
+      elseif tbl.default
+        tbl.default @
       else
-        error "don't know how to respond to #{@req.cmd_mth}"
+        methods = [k for k, v in pairs tbl when k == k\upper!]
+        @app.handle_405 @, methods
 
     if error_response = tbl.on_error
       out = capture_errors out, error_response

--- a/lapis/application.moon
+++ b/lapis/application.moon
@@ -468,6 +468,15 @@ respond_to = do
 
     out
 
+restrict = (methods, action) ->
+  if action == nil
+    action = methods
+    methods = {'GET', 'HEAD'}
+  =>
+    for method in *methods
+      return action @ if @req.cmd_mth == method
+    @app.handle_405 @, methods
+
 default_error_response = -> { render: true }
 capture_errors = (fn, error_response=default_error_response) ->
   if type(fn) == "table"
@@ -516,7 +525,7 @@ json_params = (fn) ->
     fn @, ...
 
 {
-  :Request, :Application, :respond_to
+  :Request, :Application, :respond_to, :restrict
   :capture_errors, :capture_errors_json
   :json_params, :assert_error, :yield_error
 }


### PR DESCRIPTION
I propose the following:

(first commit)

 - Possibility to define a `default` handler in the table that is fed to `lapis.application.respond_to`.
 - Pre-defined `handle_405` application callback on `lapis.application.Application` which produces a header-only response with status `405 Not Allowed` and an `Allow` header.
 - In the absence of a `default` handler, `respond_to` falls through to `@app.handle_405` instead of raising a hard error when the HTTP verb doesn't match any of the keys.
 - Documentation for all of the above.

(second commit)

 - New action decorator `lapis.application.restrict` which enables the user to list the allowed verbs and define a single action that handles all of them.
 - Documentation for the new `restrict` decorator.

**Rationale**

Requesting an unsupported verb is a client error, not a server error (hence the existence of the standardised 405 status code and the standardised `Allow` response header). Arguably, returning 405 is a more sensible default to provide to library users than raising a hard error. I believe the proposed mechanism does not hinder debugging; either approach will tell the developer that an unsupported verb was requested.

The `default` handler for `respond_to` may be useful especially in public RESTful APIs, where the server may opt to return specific documentation when a client requests an unsupported verb on a path. In general, there is no reason why a developer may not wish to special-case handling of unsupported verbs for particular actions.

The new `restrict` decorator covers common cases where, for example, both `GET` and `HEAD` are allowed, while the implementation is nearly the same. It is also a simple way to restrict a route to any verb(s) of choice.

**Possible further improvements**

 - The default 405 callback is header-only. For increased human-friendliness, a short body text could be included.
 - In my opinion, the default `handle_404` callback should take a similar approach as the newly proposed `handle_405` callback. Requesting a nonexistant path is a client error, not a server error.
 - If the table fed to `respond_to` contains both a `before` item and a `default` item and the verb falls through to `default`, the `before` function is not applied. Depending on the exact semantics of these fields, it may be better to apply the `before` to the `default` (but not to the `@app.handle_405` backup fallthrough; that would change the semantics of `before` compared to the current situation).
 - If the `restrict` decorator is accepted and deemed convenient enough for use in plain old Lua, `lapis.application.Application:get` et al may be considered obsolete.
 - If an `Application` subclass `@include`s another `Application` subclass, the `handle_40x` callbacks of the `@include`r apply for all actions, and the corresponding callbacks of the `@include`e are ignored. Fixing that in the same way as was done for the `@before_filter` would be a chore. However, with a redesign of the `@include`ing a more elegant solution may be possible.