### PR TITLE
validation now can show what fields have failed

### DIFF
--- a/lapis/validate.lua
+++ b/lapis/validate.lua
@@ -65,7 +65,10 @@ test_input = function(input, func, args)
   return fn(input, unpack(args))
 end
 local validate
-validate = function(object, validations)
+validate = function(object, validations, opts)
+  if opts == nil then
+    opts = { }
+  end
   local errors = { }
   for _index_0 = 1, #validations do
     local _continue_0 = false
@@ -90,7 +93,11 @@ validate = function(object, validations)
           end
           local success, msg = test_input(input, fn, args)
           if not (success) then
-            insert(errors, (error_msg or msg):format(key))
+            if opts.keys and opts.keys == true then
+              errors[key] = (error_msg or msg):format(key)
+            else
+              insert(errors, (error_msg or msg):format(key))
+            end
             break
           end
           _continue_1 = true

--- a/lapis/validate.moon
+++ b/lapis/validate.moon
@@ -52,7 +52,7 @@ test_input = (input, func, args) ->
   args = {args} if type(args) != "table"
   fn input, unpack args
 
-validate = (object, validations) ->
+validate = (object, validations, opts = {}) ->
   errors = {}
   for v in *validations
     key = v[1]
@@ -69,7 +69,10 @@ validate = (object, validations) ->
       continue unless type(fn) == "string"
       success, msg = test_input input, fn, args
       unless success
-        insert errors, (error_msg or msg)\format key
+        if opts.keys and opts.keys == true
+          errors[key] = (error_msg or msg)\format key
+        else
+          insert errors, (error_msg or msg)\format key
         break
 
   next(errors) and errors

--- a/spec/validate_spec.moon
+++ b/spec/validate_spec.moon
@@ -87,3 +87,14 @@ describe "lapis.validate", ->
     it "should match", ->
       errors = validate o, input
       assert.same errors, output
+  
+  it "should get key with error", ->
+    errors = validate o, {
+      { "age", exists: true }
+      { "name", exists: true }
+      { "rupture", exists: true, "rupture is required" }
+    }, {keys: true }
+    assert.same errors, {
+      age: "age must be provided",
+      rupture: "rupture is required"
+    }


### PR DESCRIPTION
Validation errors with keys!

When developing web applications/web services, etc is a common task to indicate that form elements or params have failed in data validation (without comparing string or whatever)
So using (notice 3rd parameter)
```moonscript
    errors = validate o, {
      { "age", exists: true }
      { "name", exists: true }
      { "rupture", exists: true, "a custom message here" }
    }, { key: true }
```
you can get something like this:
```moonscript
 {
  age: 'age must be provided',
  rupture; 'a custom message here' 
}
```
