### PR TITLE
Clarified wording in docs/html_generation.md

### DIFF
--- a/docs/html_generation.md
+++ b/docs/html_generation.md
@@ -154,7 +154,7 @@ with the same name as the action:
   render: true
 ```
 
-By default `views.` is appended to the front of the widget name and then loaded
+By default `views.` is prepended to the widget name and then loaded
 using Lua's `require` function. The `views` prefix can be customized by
 overwriting the `views_prefix` member of your application subclass:
 


### PR DESCRIPTION
"is prepended to" makes more sense than "is appended to the front of" and is less wordy.