### PR TITLE
Allow migrations to run on remote mysql hosts

### DIFF
--- a/lapis/db/mysql.lua
+++ b/lapis/db/mysql.lua
@@ -20,7 +20,18 @@ BACKENDS = {
     local config = require("lapis.config").get()
     local mysql_config = assert(config.mysql, "missing mysql configuration")
     local luasql = require("luasql.mysql").mysql()
-    conn = assert(luasql:connect(mysql_config.database, mysql_config.user, mysql_config.password))
+    local conn_opts = {
+      mysql_config.database,
+      mysql_config.user,
+      mysql_config.password
+    }
+    if mysql_config.host then
+      table.insert(conn_opts, mysql_config.host)
+      if mysql_config.port then
+        table.insert(conn_opts, mysql_config.port)
+      end
+    end
+    conn = assert(luasql:connect(unpack(conn_opts)))
     return function(q)
       if logger then
         logger.query(q)

--- a/lapis/db/mysql.moon
+++ b/lapis/db/mysql.moon
@@ -28,8 +28,11 @@ BACKENDS = {
     mysql_config = assert config.mysql, "missing mysql configuration"
 
     luasql = require("luasql.mysql").mysql!
-    conn = assert luasql\connect mysql_config.database,
-      mysql_config.user, mysql_config.password
+    conn_opts = { mysql_config.database, mysql_config.user, mysql_config.password }
+    if mysql_config.host
+      table.insert conn_opts, mysql_config.host
+      if mysql_config.port then table.insert conn_opts, mysql_config.port
+    conn = assert luasql\connect unpack(conn_opts)
 
     (q) ->
       logger.query q if logger


### PR DESCRIPTION
I've added host and port to LuaSQL-mysql adapter to allow remote connections when running migrations. Sorry I couldn't add any specs related to this, let me know if you want it, then I can spend more time on it.