### PR TITLE
Add error labels to parsers via LPegLabel

### DIFF
--- a/lapis/db/postgres.lua
+++ b/lapis/db/postgres.lua
@@ -296,7 +296,7 @@ do
     }
     local P, R, C, S, Cmt, Ct, Cg, V
     do
-      local _obj_0 = require("lpeg")
+      local _obj_0 = require("lpeglabel")
       P, R, C, S, Cmt, Ct, Cg, V = _obj_0.P, _obj_0.R, _obj_0.C, _obj_0.S, _obj_0.Cmt, _obj_0.Ct, _obj_0.Cg, _obj_0.V
     end
     local alpha = R("az", "AZ", "__")
@@ -309,7 +309,7 @@ do
     local strings = single_string + double_string
     local ci
     ci = function(str)
-      S = require("lpeg").S
+      S = require("lpeglabel").S
       local p
       for c in str:gmatch(".") do
         local char = S(tostring(c:lower()) .. tostring(c:upper()))

--- a/lapis/db/postgres.moon
+++ b/lapis/db/postgres.moon
@@ -234,7 +234,7 @@ parse_clause = do
   make_grammar = ->
     basic_keywords = {"where", "having", "limit", "offset"}
 
-    import P, R, C, S, Cmt, Ct, Cg, V from require "lpeg"
+    import P, R, C, S, Cmt, Ct, Cg, V from require "lpeglabel"
 
     alpha = R("az", "AZ", "__")
     alpha_num = alpha + R("09")
@@ -248,7 +248,7 @@ parse_clause = do
 
     -- case insensitive word
     ci = (str) ->
-      import S from require "lpeg"
+      import S from require "lpeglabel"
       local p
 
       for c in str\gmatch "."

--- a/lapis/router.lua
+++ b/lapis/router.lua
@@ -1,6 +1,6 @@
 local insert
 insert = table.insert
-local lpeg = require("lpeg")
+local lpeg = require("lpeglabel")
 local R, S, V, P
 R, S, V, P = lpeg.R, lpeg.S, lpeg.V, lpeg.P
 local C, Cs, Ct, Cmt, Cg, Cb, Cc

--- a/lapis/router.moon
+++ b/lapis/router.moon
@@ -6,7 +6,7 @@
 
 import insert from table
 
-lpeg = require "lpeg"
+lpeg = require "lpeglabel"
 
 import R, S, V, P from lpeg
 import C, Cs, Ct, Cmt, Cg, Cb, Cc from lpeg

--- a/lapis/router.moon
+++ b/lapis/router.moon
@@ -8,7 +8,7 @@ import insert from table
 
 lpeg = require "lpeglabel"
 
-import R, S, V, P from lpeg
+import R, S, V, P, T from lpeg
 import C, Cs, Ct, Cmt, Cg, Cb, Cc from lpeg
 
 import encode_query_string from require "lapis.util"
@@ -34,12 +34,28 @@ route_precedence = (flags) ->
   p
 
 class RouteParser
+  @labels = {
+    {"mis_name",           "missing a variable name after the ':'"},
+    {"mis_class",          "missing a character class after the '['"},
+    {"mis_close_bracket",  "missing the closing ']'"},
+    {"mis_route",          "missing an optional route after the '('"},
+    {"mis_close_paren",    "missing the closing ')'"}
+  }
+
   new: =>
     @grammar = @build_grammar!
 
   -- returns an lpeg patternt that matches route, along with table of flags
   parse: (route) =>
-    @grammar\match route
+    result, label, suffix = @grammar\match route
+    if result == nil
+      msg = "syntax error in route:"
+      msg ..= "\n" .. route
+      msg ..= "\n" .. " "\rep(route\len() - suffix\len()) .. "^"
+      msg ..= "\n" .. @@labels[label][2]
+      error(msg)
+
+    result, label
 
   compile_exclude: (current_p, chunks, k=1) =>
     local out
@@ -155,6 +171,13 @@ class RouteParser
     out or P -1
 
   build_grammar: =>
+    expect = (patt, label_name) ->
+      for i, {ln, msg} in ipairs @@labels
+        if ln == label_name
+          return patt + T(i)
+
+      error "label not found"
+
     alpha = R("az", "AZ", "__")
     alpha_num = alpha + R("09")
 
@@ -164,8 +187,8 @@ class RouteParser
     make_optional = (children) -> { "optional", children }
 
     splat = P"*"
-    var = P":" * alpha * alpha_num^0
-    var = C(var) * (P"[" * C((1 - P"]")^1) * P"]")^-1
+    var = P":" * expect(alpha * alpha_num^0, "mis_name")
+    var = C(var) * (P"[" * expect(C((1 - P"]")^1), "mis_class") * expect(P"]", "mis_close_bracket"))^-1
 
     @var = var
     @splat = splat
@@ -179,7 +202,7 @@ class RouteParser
       "route"
       optional_literal: (1 - P")" - V"chunk")^1 / make_lit
       optional_route: Ct((V"chunk" + V"optional_literal")^1)
-      optional: P"(" * V"optional_route" * P")" / make_optional
+      optional: P"(" * expect(V"optional_route", "mis_route") * expect(P")", "mis_close_paren") / make_optional
 
       literal: (1 - V"chunk")^1 / make_lit
       chunk: var / make_var + splat / make_splat + V"optional"

--- a/lapis/util.lua
+++ b/lapis/util.lua
@@ -41,7 +41,7 @@ end
 do
   local C, P, S, Ct
   do
-    local _obj_0 = require("lpeg")
+    local _obj_0 = require("lpeglabel")
     C, P, S, Ct = _obj_0.C, _obj_0.P, _obj_0.S, _obj_0.Ct
   end
   local char = (P(1) - S("=&"))
@@ -82,7 +82,7 @@ end
 do
   local C, R, P, S, Ct, Cg
   do
-    local _obj_0 = require("lpeg")
+    local _obj_0 = require("lpeglabel")
     C, R, P, S, Ct, Cg = _obj_0.C, _obj_0.R, _obj_0.P, _obj_0.S, _obj_0.Ct, _obj_0.Cg
   end
   local white = S(" \t") ^ 0

--- a/lapis/util.moon
+++ b/lapis/util.moon
@@ -29,7 +29,7 @@ inject_tuples = (tbl) ->
     tbl[tuple[1]] = tuple[2] or true
 
 parse_query_string = do
-  import C, P, S, Ct from require "lpeg"
+  import C, P, S, Ct from require "lpeglabel"
 
   char = (P(1) - S("=&"))
 
@@ -64,7 +64,7 @@ encode_query_string = (t, sep="&") ->
   concat buf
 
 parse_content_disposition = do
-  import C, R, P, S, Ct, Cg from require "lpeg"
+  import C, R, P, S, Ct, Cg from require "lpeglabel"
 
   white = S" \t"^0
   token = C (R("az", "AZ", "09") + S"._-")^1


### PR DESCRIPTION
This patch adds error messages to the route parser (for building URLs) and the Postgres clause parser. Error detection is done via labels through LPegLabel (an extension of LPeg). [Here's a short report with the details of the changes including a few examples for each error](https://github.com/leafo/lapis/files/315582/ReportonLapisParsersRewrite.pdf). In total, 12 possible errors are detected (5 for the route parser, 7 for the clause parser).

I have not updated the rockspec and the travis yaml file in this PR. Is there a reason why travis is configured to use an older version of LPeg by the way? LPegLabel is currently based on LPeg v0.12.2 and work is already being done to update it to use LPeg v1.0. Please tell me if this will be an issue.
