### PR TITLE
Fix missing "set $_url '';" in nginx.conf generation

### DIFF
--- a/lapis/cmd/templates/config.moon
+++ b/lapis/cmd/templates/config.moon
@@ -18,6 +18,7 @@ http {
 
     location / {
       default_type text/html;
+      set $_url '';
       content_by_lua '
         require("lapis").serve("app")
       ';


### PR DESCRIPTION
See #100

This line should be in `nginx.conf` generated by `lapis new`, but it is not. This fixes that.
