### PR TITLE
added return in app.lua examples

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -116,6 +116,8 @@ app:match("/", function()
   local res = db.query("select * from my_table where id = ?", 10)
   return "ok!"
 end)
+
+return app
 ```
 
 ```moon
@@ -142,6 +144,8 @@ app:match("/", function()
   local row = MyTable:find(10)
   return "ok!"
 end)
+
+return app
 ```
 
 ```moon


### PR DESCRIPTION
Added return in app.lua examples. For completeness sake. Otherwise results in internal server error if you forget to return the app object.