### PR TITLE
Added lua and moonscript mime types

### DIFF
--- a/lapis/cmd/templates/mime_types.moon
+++ b/lapis/cmd/templates/mime_types.moon
@@ -5,6 +5,8 @@ types {
     text/xml                              xml;
     image/gif                             gif;
     image/jpeg                            jpeg jpg;
+    application/x-lua                     lua;
+    application/x-moonscript              moon;
     application/x-javascript              js;
     application/atom+xml                  atom;
     application/rss+xml                   rss;


### PR DESCRIPTION
I don't know why these were even missing. An application written in lua/moonscript should know what lua/moonscript is, right? Every program should know their parents, right?