### PR TITLE
Added `add_headers()` method to request objects

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -394,6 +394,7 @@ Additionally the request object has the following methods:
 * `url_for(route, params, ...)` -- get the URL for a named route, or object
 * `build_url(path, params)` -- build a fully qualified URL from a path and parameters
 * `html(fn)` -- generate a string using the HTML builder syntax
+* `add_headers(headers)` -- Adds response headers
 
 ### @req
 

--- a/lapis/nginx.lua
+++ b/lapis/nginx.lua
@@ -198,7 +198,6 @@ build_response = function()
         self.headers[k] = v
       elseif "table" == _exp_0 then
         old[#old + 1] = v
-        self.headers[k] = old
       else
         self.headers[k] = {
           old,

--- a/lapis/nginx.moon
+++ b/lapis/nginx.moon
@@ -133,7 +133,6 @@ build_response = ->
           @headers[k] = v
         when "table"
           old[#old + 1] = v
-          @headers[k] = old
         else
           @headers[k] = {old, v}
 

--- a/lapis/request.lua
+++ b/lapis/request.lua
@@ -104,6 +104,13 @@ do
       self.buffer = { }
       self.params = { }
       self.options = { }
+      local _ = {
+        [self.add_headers] = function(self, headers)
+          for k, v in pairs(headers) do
+            self.res:add_header(k, v)
+          end
+        end
+      }
       self.__class.support.load_cookies(self)
       return self.__class.support.load_session(self)
     end,

--- a/lapis/request.moon
+++ b/lapis/request.moon
@@ -155,6 +155,9 @@ class Request
     @buffer = {} -- output buffer
     @params = {}
     @options = {}
+    @add_headers: (headers) =>
+    	for k,v in pairs headers
+    		@res\add_header k,v
 
     @@support.load_cookies @
     @@support.load_session @


### PR DESCRIPTION
##Why?
Because sometimes you may want to set headers progressively instead of just having one long header table at the end of your code. Specially useful when setting defaults in before-filters (UTF-8, spoofing the server, adding a lapis version header, etc.)

##How?
By just adding a simple method that calls the add_header method of the response object (see code)

#Example
```lua
app:before_filter(function(self)	
	self:add_headers {
		content_type = "text/html; charset=utf-8";
		lapis_version = require "lapis.version";
		server = "Super Secret, even if you knew you wouldn't find any vulnerabilities on google!"
	}
end)
```

I also couldn't resist removing a line of code that did absolutely nothing (again, see code)