### PR TITLE
docs: fix ambiguity for database config

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -39,6 +39,7 @@ file.
 
 ```lua
 -- config.lua
+local config = require("lapis.config")
 config("development", {
   postgres = {
     host = "127.0.0.1",
@@ -51,6 +52,7 @@ config("development", {
 
 ```moon
 -- config.moon
+import config from require "lapis.config"
 config "development", ->
   postgres ->
     host "127.0.0.1"
@@ -71,6 +73,7 @@ block:
 
 ```lua
 -- config.lua
+local config = require("lapis.config")
 config("development", {
   mysql = {
     host = "127.0.0.1",
@@ -83,6 +86,7 @@ config("development", {
 
 ```moon
 -- config.moon
+import config from require "lapis.config"
 config "development", ->
   mysql ->
     host "127.0.0.1"


### PR DESCRIPTION
This one tripped me up. I copy-pasted the code from the docs into the code and was wondering why I was getting `attempt to call global 'config' (a nil value)`.