### PR TITLE
Added cookie check for CSRF protection, very IMPORTANT mechanism

### DIFF
--- a/lapis/csrf.lua
+++ b/lapis/csrf.lua
@@ -15,7 +15,9 @@ generate_token = function(req, key, expires)
     expires = expires
   }))
   local signature = encode_base64(hmac_sha1(config.secret, msg))
-  return msg .. "." .. signature
+  local token = msg .. "." .. signature
+  req.cookies.csrf_token = token
+  return token
 end
 local validate_token
 validate_token = function(req, key)
@@ -37,6 +39,9 @@ validate_token = function(req, key)
   end
   if not (not msg.expires or msg.expires > os.time()) then
     return nil, "csrf token expired"
+  end
+  if not (req.cookies.csrf_token == token) then
+    return nil, "invalid csrf token (cookie verification failed)"
   end
   return true
 end

--- a/lapis/csrf.moon
+++ b/lapis/csrf.moon
@@ -9,7 +9,9 @@ config = require"lapis.config".get!
 generate_token = (req, key, expires=os.time! + 60*60*8) ->
   msg = encode_base64 json.encode { :key, :expires }
   signature = encode_base64 hmac_sha1 config.secret, msg
-  msg .. "." .. signature
+  token = msg .. "." .. signature
+  req.cookies.csrf_token = token
+  token
 
 validate_token = (req, key) ->
   token = req.params.csrf_token
@@ -27,6 +29,7 @@ validate_token = (req, key) ->
 
   return nil, "invalid csrf token (bad key)" unless msg.key == key
   return nil, "csrf token expired" unless not msg.expires or msg.expires > os.time!
+  return nil, "invalid csrf token (cookie verification failed)" unless req.cookies.csrf_token == token
   true
 
 assert_token = (...) ->


### PR DESCRIPTION
Generally CSRF protection must have cookie checks.
Without cookie checking, CSRF protection is pointless.
Learn more about how CSRF protection uses browser's cookie behaviour to work on this link.
https://www.vlent.nl/weblog/2016/11/16/how-does-the-django-cross-site-request-forgery-protection-work/