### PR TITLE
Allow host configuration parameter for cqueues/lua-http server

### DIFF
--- a/lapis/cmd/cqueues.lua
+++ b/lapis/cmd/cqueues.lua
@@ -135,7 +135,7 @@ create_server = function(app_module)
     end
   end
   local server = http_server.listen({
-    host = "127.0.0.1",
+    host = config.host or "127.0.0.1",
     port = assert(config.port, "missing server port"),
     onstream = onstream,
     onerror = function(self, context, op, err, errno)

--- a/lapis/cmd/cqueues.moon
+++ b/lapis/cmd/cqueues.moon
@@ -65,7 +65,7 @@ create_server = (app_module) ->
     (stream) => dispatch app, @, stream
 
   server = http_server.listen {
-    host: "127.0.0.1"
+    host: config.host or "127.0.0.1"
     port: assert config.port, "missing server port"
 
     :onstream


### PR DESCRIPTION
When using lua-http server the socket is hardwired to 127.0.0.1, this little change takes in account config.host from configuration.