### PR TITLE
Add Support for concurrent indexes on postgres

### DIFF
--- a/lapis/db/postgres/schema.moon
+++ b/lapis/db/postgres/schema.moon
@@ -62,6 +62,8 @@ create_index = (tname, ...) ->
     escape_identifier(index_name),
     " ON ", escape_identifier tname
 
+  append_all buffer, " CONCURRENTLY " if options.concurrently
+
   if options.method
     append_all buffer, " USING ", options.method
     


### PR DESCRIPTION
Concurrent indexes are useful for large tables because they do not lock the table from writes.

I'm making this PR as a starting point. I'm happy add docs and test cases if this seems useful to others. 😄 