### PR TITLE
Use content_by_lua_block in place of the discouraged content_by_lua

### DIFF
--- a/lapis/cmd/nginx/templates/config.lua
+++ b/lapis/cmd/nginx/templates/config.lua
@@ -16,9 +16,9 @@ http {
 
     location / {
       default_type text/html;
-      content_by_lua '
+      content_by_lua_block {
         require("lapis").serve("app")
-      ';
+      }
     }
 
     location /static/ {

--- a/lapis/cmd/nginx/templates/config.moon
+++ b/lapis/cmd/nginx/templates/config.moon
@@ -18,9 +18,9 @@ http {
 
     location / {
       default_type text/html;
-      content_by_lua '
+      content_by_lua_block {
         require("lapis").serve("app")
-      ';
+      }
     }
 
     location /static/ {


### PR DESCRIPTION
See [docs](https://github.com/openresty/lua-nginx-module#content_by_lua) for statement recommending users use `content_by_lua_block` instead.