### PR TITLE
Add "timeout" config option for Postgres

### DIFF
--- a/lapis/db/postgres.moon
+++ b/lapis/db/postgres.moon
@@ -50,6 +50,11 @@ BACKENDS = {
       unless pgmoon
         import Postgres from require "pgmoon"
         pgmoon = Postgres pg_config
+        
+        if pg_config.timeout
+          pg_timeout = assert tonumber(pg_config.timeout), "timeout must be a number (ms)"
+          pgmoon\settimeout pg_timeout
+        
         assert pgmoon\connect!
 
         if ngx


### PR DESCRIPTION
If present, this will apply the `timeout` field in a Lapis postgres config block to the socket opened by pgmoon. This will technically also pass the same field to the constructor [here](https://github.com/leafo/pgmoon/blob/df9c974ecf9d4ba707594c483a2985ebf75eb900/pgmoon/init.moon#L155), but it's ignored there.