### PR TITLE
Update moon_getting_started.md

### DIFF
--- a/docs/moon_getting_started.md
+++ b/docs/moon_getting_started.md
@@ -32,7 +32,7 @@ return value.)
 
 > Don't forget to compile the `.moon` files when changing and creating them.
 > You can watch the current directory and compile automatically with `moonc
-> -w`.
+> -w` but be aware new files aren’t picked up, you have to restart `moonc`.
 
 Try it out by starting the server:
 


### PR DESCRIPTION
having started with lapis' docs rather than moonscript's it took me a looooong time to understand why I kept getting "runtime error: You have to configure either postgres or mysql" even though config.moon was correct (I had created it after starting moonc -w)