### PR TITLE
Clarify table limitation on custom validation functions

### DIFF
--- a/docs/input_validation.md
+++ b/docs/input_validation.md
@@ -62,7 +62,8 @@ table with a list of validations to perform. Each validation is the following fo
 `Validation_Key` is the key to fetch from the table being validated.
 
 Any number of validation functions can be provided. If a validation function
-takes multiple arguments, an array table can be passed
+takes multiple arguments, pass an array table. (Note: A single table argument
+cannot be used, it will be unpacked into arguments.)
 
 `Error_Message` is an optional second positional value. If provided it will be
 used as the validation failure error message instead of the default generated


### PR DESCRIPTION
> Tables are unpacked to allow multiple arguments to be specified, which means a single table cannot be passed as THE argument.

I was attempting to pass a hash table as an argument to a validation function, but as a table passed as an argument to a validation function is passed through `unpack`, my hash table was sent as zero arguments instead. I understand why it works this way, but it was frustrating to find out the hard way I could not do what I intended.