### PR TITLE
Update sqlite.lua

### DIFF
--- a/lapis/db/sqlite.lua
+++ b/lapis/db/sqlite.lua
@@ -1,9 +1,13 @@
+-- sqlite.lua from lapis.db.sqlite
+-- version 1.16
+-- modified by Michael Stephan to support SQLite specific features and optimizations.
+
 local concat
 concat = table.concat
 local type, tostring, pairs, select
 do
-  local _obj_0 = _G
-  type, tostring, pairs, select = _obj_0.type, _obj_0.tostring, _obj_0.pairs, _obj_0.select
+    local _obj_0 = _G
+    type, tostring, pairs, select = _obj_0.type, _obj_0.tostring, _obj_0.pairs, _obj_0.select
 end
 local unpack = unpack or table.unpack
 local base_db = require("lapis.db.base")
@@ -14,252 +18,296 @@ local measure_performance = false
 local gettime
 local append_all
 append_all = function(t, ...)
-  for i = 1, select("#", ...) do
-    t[#t + 1] = select(i, ...)
-  end
+    for i = 1, select("#", ...) do
+        t[#t + 1] = select(i, ...)
+    end
 end
 local active_connection
 local escape_identifier
 escape_identifier = function(ident)
-  if is_raw(ident) then
-    return ident[1]
-  end
-  if is_list(ident) then
-    local escaped_items
-    do
-      local _accum_0 = { }
-      local _len_0 = 1
-      local _list_0 = ident[1]
-      for _index_0 = 1, #_list_0 do
-        local item = _list_0[_index_0]
-        _accum_0[_len_0] = escape_identifier(item)
-        _len_0 = _len_0 + 1
-      end
-      escaped_items = _accum_0
+    if is_raw(ident) then
+        return ident[1]
     end
-    assert(escaped_items[1], "can't flatten empty list")
-    return "(" .. tostring(concat(escaped_items, ", ")) .. ")"
-  end
-  ident = tostring(ident)
-  return '"' .. (ident:gsub('"', '""')) .. '"'
+    if is_list(ident) then
+        local escaped_items
+        do
+            local _accum_0 = {}
+            local _len_0 = 1
+            local _list_0 = ident[1]
+            for _index_0 = 1, #_list_0 do
+                local item = _list_0[_index_0]
+                _accum_0[_len_0] = escape_identifier(item)
+                _len_0 = _len_0 + 1
+            end
+            escaped_items = _accum_0
+        end
+        assert(escaped_items[1], "can't flatten empty list")
+        return "(" .. tostring(concat(escaped_items, ", ")) .. ")"
+    end
+    ident = tostring(ident)
+    return '"' .. (ident:gsub('"', '""')) .. '"'
 end
 local escape_literal
 escape_literal = function(val)
-  local _exp_0 = type(val)
-  if "number" == _exp_0 then
-    return tostring(val)
-  elseif "string" == _exp_0 then
-    return "'" .. tostring((val:gsub("'", "''"))) .. "'"
-  elseif "boolean" == _exp_0 then
-    return val and "TRUE" or "FALSE"
-  elseif "table" == _exp_0 then
-    if val == NULL then
-      return "NULL"
-    end
-    if is_list(val) then
-      local escaped_items
-      do
-        local _accum_0 = { }
-        local _len_0 = 1
-        local _list_0 = val[1]
-        for _index_0 = 1, #_list_0 do
-          local item = _list_0[_index_0]
-          _accum_0[_len_0] = escape_literal(item)
-          _len_0 = _len_0 + 1
+    local _exp_0 = type(val)
+    if "number" == _exp_0 then
+        return tostring(val)
+    elseif "string" == _exp_0 then
+        return "'" .. tostring((val:gsub("'", "''"))) .. "'"
+    elseif "boolean" == _exp_0 then
+        return val and "TRUE" or "FALSE"
+    elseif "table" == _exp_0 then
+        if val == NULL then
+            return "NULL"
         end
-        escaped_items = _accum_0
-      end
-      assert(escaped_items[1], "can't flatten empty list")
-      return "(" .. tostring(concat(escaped_items, ", ")) .. ")"
+        if is_list(val) then
+            local escaped_items
+            do
+                local _accum_0 = {}
+                local _len_0 = 1
+                local _list_0 = val[1]
+                for _index_0 = 1, #_list_0 do
+                    local item = _list_0[_index_0]
+                    _accum_0[_len_0] = escape_literal(item)
+                    _len_0 = _len_0 + 1
+                end
+                escaped_items = _accum_0
+            end
+            assert(escaped_items[1], "can't flatten empty list")
+            return "(" .. tostring(concat(escaped_items, ", ")) .. ")"
+        end
+        if is_raw(val) then
+            return val[1]
+        end
+        error("unknown table passed to `escape_literal`")
     end
-    if is_raw(val) then
-      return val[1]
-    end
-    error("unknown table passed to `escape_literal`")
-  end
-  return error("don't know how to escape value: " .. tostring(val))
+    return error("don't know how to escape value: " .. tostring(val))
 end
-local interpolate_query, encode_values, encode_assigns, encode_clause = base_db.build_helpers(escape_literal, escape_identifier)
+local interpolate_query, encode_values, encode_assigns, encode_clause = base_db.build_helpers(escape_literal,
+    escape_identifier)
 local connect
 connect = function()
-  if active_connection then
-    active_connection:close()
-    active_connection = nil
-  end
-  local sqlite3 = require("lsqlite3")
-  local config = require("lapis.config").get()
-  local db_name = config.sqlite and config.sqlite.database or "lapis.sqlite"
-  local open_flags = config.sqlite and config.sqlite.open_flags
-  measure_performance = config.measure_performance
-  if measure_performance then
-    gettime = require("socket").gettime
-  end
-  active_connection = assert(sqlite3.open(db_name, open_flags))
+    if active_connection then
+        active_connection:close()
+        active_connection = nil
+    end
+    local sqlite3 = require("lsqlite3")
+    local config = require("lapis.config").get()
+    local db_name = config.sqlite and config.sqlite.database or "lapis.sqlite"
+    local open_flags = config.sqlite and config.sqlite.open_flags
+    local pragma_defaults = config.sqlite and config.sqlite.connection_pragma_defaults
+    measure_performance = config.measure_performance
+    if measure_performance then
+        gettime = require("socket").gettime
+    end
+    active_connection = assert(sqlite3.open(db_name, open_flags))
+    if pragma_defaults then
+        local pragma_sql = {}
+        for k, v in pairs(pragma_defaults) do
+            pragma_sql[#pragma_sql + 1] = "PRAGMA "
+                .. escape_literal(k) .. " = "
+                .. escape_literal(v) .. ";"
+        end
+        local sql = table.concat(pragma_sql, "\n")
+        local rc = active_connection:exec(sql)
+        if rc ~= sqlite3.OK then
+            error("Failed to set pragma defaults: " .. rc)
+        end
+    end
+end
+local exec
+exec = function(sql, func, udata)
+    if not (active_connection) then
+        connect()
+    end
+    return active_connection:exec(sql, func, udata)
+end
+local exec_scalar
+exec_scalar = function(sql)
+    if not (active_connection) then
+        connect()
+    end
+    local scalar_value
+    local rc = active_connection:exec(sql, function(udata, cols, values, names)
+        scalar_value = values and values[1]
+        return 0
+    end)
+    return rc == 0 and scalar_value or nil
+end
+local prepare
+prepare = function(sql)
+    if not (active_connection) then
+        connect()
+    end
+    return active_connection:prepare(sql)
 end
 local query
 query = function(str, ...)
-  if not (active_connection) then
-    connect()
-  end
-  if select("#", ...) > 0 then
-    str = interpolate_query(str, ...)
-  end
-  local start_time
-  if measure_performance then
-    start_time = gettime()
-  else
-    logger.query(str)
-  end
-  local result
-  do
-    local _accum_0 = { }
-    local _len_0 = 1
-    for row in active_connection:nrows(str) do
-      _accum_0[_len_0] = row
-      _len_0 = _len_0 + 1
+    if not (active_connection) then
+        connect()
     end
-    result = _accum_0
-  end
-  if start_time then
-    local dt = gettime() - start_time
-    logger.query(str, dt)
-  end
-  return result
+    if select("#", ...) > 0 then
+        str = interpolate_query(str, ...)
+    end
+    local start_time
+    if measure_performance then
+        start_time = gettime()
+    else
+        logger.query(str)
+    end
+    local result
+    do
+        local _accum_0 = {}
+        local _len_0 = 1
+        for row in active_connection:nrows(str) do
+            _accum_0[_len_0] = row
+            _len_0 = _len_0 + 1
+        end
+        result = _accum_0
+    end
+    if start_time then
+        local dt = gettime() - start_time
+        logger.query(str, dt)
+    end
+    return result
 end
 local add_returning
 add_returning = function(buff, first, cur, following, ...)
-  if not (cur) then
-    return 
-  end
-  if first then
-    append_all(buff, " RETURNING ")
-  end
-  append_all(buff, escape_identifier(cur))
-  if following then
-    append_all(buff, ", ")
-    return add_returning(buff, false, following, ...)
-  end
+    if not (cur) then
+        return
+    end
+    if first then
+        append_all(buff, " RETURNING ")
+    end
+    append_all(buff, escape_identifier(cur))
+    if following then
+        append_all(buff, ", ")
+        return add_returning(buff, false, following, ...)
+    end
 end
 local add_cond
 add_cond = function(buffer, cond, ...)
-  append_all(buffer, " WHERE ")
-  local _exp_0 = type(cond)
-  if "table" == _exp_0 then
-    return encode_clause(cond, buffer)
-  elseif "string" == _exp_0 then
-    return append_all(buffer, interpolate_query(cond, ...))
-  end
+    append_all(buffer, " WHERE ")
+    local _exp_0 = type(cond)
+    if "table" == _exp_0 then
+        return encode_clause(cond, buffer)
+    elseif "string" == _exp_0 then
+        return append_all(buffer, interpolate_query(cond, ...))
+    end
 end
 local insert
 insert = function(tbl, values, opts, ...)
-  local buff = {
-    "INSERT INTO ",
-    escape_identifier(tbl),
-    " "
-  }
-  if next(values) then
-    encode_values(values, buff)
-  else
-    append_all(buff, "DEFAULT VALUES")
-  end
-  local opts_type = type(opts)
-  if opts_type == "string" or opts_type == "table" and is_raw(opts) then
-    add_returning(buff, true, opts, ...)
-  elseif opts_type == "table" then
-    if opts.on_conflict then
-      if opts.on_conflict == "do_nothing" then
-        append_all(buff, " ON CONFLICT DO NOTHING")
-      else
-        error("db.insert: unsupported value for on_conflict option: " .. tostring(tostring(opts.on_conflict)))
-      end
+    local buff = {
+        "INSERT INTO ",
+        escape_identifier(tbl),
+        " "
+    }
+    if next(values) then
+        encode_values(values, buff)
+    else
+        append_all(buff, "DEFAULT VALUES")
     end
-    do
-      local r = opts.returning
-      if r then
-        if r == "*" then
-          add_returning(buff, true, raw("*"))
-        else
-          assert(type(r) == "table" and not is_raw(r), "db.insert: returning option must be a table array")
-          add_returning(buff, true, unpack(r))
+    local opts_type = type(opts)
+    if opts_type == "string" or opts_type == "table" and is_raw(opts) then
+        add_returning(buff, true, opts, ...)
+    elseif opts_type == "table" then
+        if opts.on_conflict then
+            if opts.on_conflict == "do_nothing" then
+                append_all(buff, " ON CONFLICT DO NOTHING")
+            else
+                error("db.insert: unsupported value for on_conflict option: " .. tostring(tostring(opts.on_conflict)))
+            end
         end
-      end
+        do
+            local r = opts.returning
+            if r then
+                if r == "*" then
+                    add_returning(buff, true, raw("*"))
+                else
+                    assert(type(r) == "table" and not is_raw(r), "db.insert: returning option must be a table array")
+                    add_returning(buff, true, unpack(r))
+                end
+            end
+        end
     end
-  end
-  local res = query(concat(buff))
-  res.affected_rows = active_connection:changes()
-  return res
+    local res = query(concat(buff))
+    res.affected_rows = active_connection:changes()
+    return res
 end
 local _select
 _select = function(str, ...)
-  return query("SELECT " .. str, ...)
+    return query("SELECT " .. str, ...)
 end
 local update
 update = function(table, values, cond, ...)
-  local buff = {
-    "UPDATE ",
-    escape_identifier(table),
-    " SET "
-  }
-  encode_assigns(values, buff)
-  if cond then
-    add_cond(buff, cond, ...)
-  end
-  if type(cond) == "table" then
-    add_returning(buff, true, ...)
-  end
-  local res = query(concat(buff))
-  res.affected_rows = active_connection:changes()
-  return res
+    local buff = {
+        "UPDATE ",
+        escape_identifier(table),
+        " SET "
+    }
+    encode_assigns(values, buff)
+    if cond then
+        add_cond(buff, cond, ...)
+    end
+    if type(cond) == "table" then
+        add_returning(buff, true, ...)
+    end
+    local res = query(concat(buff))
+    res.affected_rows = active_connection:changes()
+    return res
 end
 local delete
 delete = function(table, cond, ...)
-  local buff = {
-    "DELETE FROM ",
-    escape_identifier(table)
-  }
-  if not (cond and next(cond)) then
-    error("Blocking call to db.delete with no conditions. Use db.truncate")
-  end
-  if cond then
-    add_cond(buff, cond, ...)
-  end
-  if type(cond) == "table" then
-    add_returning(buff, true, ...)
-  end
-  local res = query(concat(buff))
-  res.affected_rows = active_connection:changes()
-  return res
+    local buff = {
+        "DELETE FROM ",
+        escape_identifier(table)
+    }
+    if not (cond and next(cond)) then
+        error("Blocking call to db.delete with no conditions. Use db.truncate")
+    end
+    if cond then
+        add_cond(buff, cond, ...)
+    end
+    if type(cond) == "table" then
+        add_returning(buff, true, ...)
+    end
+    local res = query(concat(buff))
+    res.affected_rows = active_connection:changes()
+    return res
 end
 local truncate
 truncate = function(...)
-  local changes = 0
-  local _list_0 = {
-    ...
-  }
-  for _index_0 = 1, #_list_0 do
-    local table = _list_0[_index_0]
-    query("DELETE FROM " .. tostring(escape_identifier(table)))
-    changes = changes + active_connection:changes()
-  end
-  return {
-    affected_rows = changes
-  }
+    local changes = 0
+    local _list_0 = {
+        ...
+    }
+    for _index_0 = 1, #_list_0 do
+        local table = _list_0[_index_0]
+        query("DELETE FROM " .. tostring(escape_identifier(table)))
+        changes = changes + active_connection:changes()
+    end
+    return {
+        affected_rows = changes
+    }
 end
 return setmetatable({
-  __type = "sqlite",
-  query = query,
-  insert = insert,
-  select = _select,
-  update = update,
-  delete = delete,
-  truncate = truncate,
-  connect = connect,
-  escape_identifier = escape_identifier,
-  escape_literal = escape_literal,
-  interpolate_query = interpolate_query,
-  encode_values = encode_values,
-  encode_assigns = encode_assigns,
-  encode_clause = encode_clause
+    __type = "sqlite",
+    query = query,
+    insert = insert,
+    select = _select,
+    update = update,
+    delete = delete,
+    truncate = truncate,
+    connect = connect,
+    exec = exec,
+    exec_scalar = exec_scalar,
+    prepare = prepare,
+    escape_identifier = escape_identifier,
+    escape_literal = escape_literal,
+    interpolate_query = interpolate_query,
+    encode_values = encode_values,
+    encode_assigns = encode_assigns,
+    encode_clause = encode_clause
 }, {
-  __index = require("lapis.db.base")
+    __index = require("lapis.db.base")
 })


### PR DESCRIPTION
Fixes https://github.com/leafo/lapis/issues/798 and https://github.com/leafo/lapis/issues/732 for SQLite in lapis\db\sqlite.lua

*NOTE: I need help correcting lapis\db\sqlite.moon, because I am not familiar with MoonScript.  Also if there is an issue with my coding style or naming conventions, please change if necessary...*

Currently there is no way to issue PRAGMA statements for connections.  Also there is no way to have transaction support for multiple SQL statements, since sqlite.lua uses lsqlite3 `db:nrows`, which only allows a single statement in SQLite.

Added functionality for setting SQLite pragma commands needed for all connections (foreign_keys, busy_timeout, etc.) in `connect` function of sqlite.lua.  To use this feature, config file would need to have a connection_pragma_defaults table like this (key is pragma command, value is pragma value):
```
sqlite = {
    database = "db/sqlite_database.db",
    connection_pragma_defaults = {
      foreign_keys = true,
      busy_timeout = 5000
    }
```

Also added the following functions
`exec` -allowing the use of lsqlite3 `db:exec` function, which allows multiple statements and transactions 
`exec_scalar` - utility function for easily retrieving a single value 
`prepare` - allowing the use of db:prepare for prepared statements

For instance, if you have the config file setup like the example above:

```
-- using updated version of sqlite.lua
local db = require("lapis.db.sqlite")
local timeout = db.exec_scalar("PRAGMA busy_timeout;")
print(timeout) -- 5000

local foreign_keys = db.exec_scalar("PRAGMA foreign_keys;")
print(foreign_keys) -- 1
```