### PR TITLE
Clarify third argument in create_tables, and clarify all supported types per database backend.

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -881,7 +881,7 @@ schema.create_table("users", {
 
   "PRIMARY KEY (id)"
 })
-````
+```
 
 ```moon
 schema = require "lapis.db.schema"


### PR DESCRIPTION
I think this is very important to clarify