### PR TITLE
Fix cqueues adapter: support multi-value response headers (Set-Cookie)

### DIFF
--- a/lapis/cqueues.lua
+++ b/lapis/cqueues.lua
@@ -138,7 +138,14 @@ dispatch = function(app, server, stream)
   local res_headers = http_headers.new()
   res_headers:append(":status", res.status and string.format("%d", res.status) or "200")
   for k, v in pairs(res.headers) do
-    res_headers:append(k, v)
+    if type(v) == "table" then
+      for _index_0 = 1, #v do
+        local vv = v[_index_0]
+        res_headers:append(k, tostring(vv))
+      end
+    else
+      res_headers:append(k, tostring(v))
+    end
   end
   stream:write_headers(res_headers, not res.content)
   if res.content then

--- a/lapis/cqueues.moon
+++ b/lapis/cqueues.moon
@@ -151,7 +151,11 @@ dispatch = (app, server, stream) ->
   res_headers\append ":status", res.status and string.format("%d", res.status) or "200"
 
   for k,v in pairs res.headers
-    res_headers\append k,v
+    if type(v) == "table"
+      for vv in *v
+        res_headers\append k, tostring(vv)
+    else
+      res_headers\append k, tostring(v)
 
   stream\write_headers res_headers, not res.content
 


### PR DESCRIPTION
This PR fixes a crash in the cqueues (lua-http) backend when an action sets more than one cookie.

Lapis stores multiple Set-Cookie values as an array in res.headers, but the cqueues adapter was appending header values directly and passed a Lua table to http.headers:append, causing field value invalid. The adapter now flattens table-valued headers and appends each value separately, allowing multiple cookies (and any multi-value header) to work correctly.

Repro: set self.cookies.csrf and self.cookies.theme alongside self.session.* → server crashes.
After: multiple Set-Cookie headers are emitted correctly